### PR TITLE
Stop sending all child process output to main process.

### DIFF
--- a/procstreams.js
+++ b/procstreams.js
@@ -145,8 +145,6 @@ procStream._prototype = {
     this._out = true;
 
     var opts = { end: false }
-    this.stdout.pipe(process.stdout, opts);
-    this.stderr.pipe(process.stderr, opts);
 
     return this;
   }


### PR DESCRIPTION
This was probably there for debugging but needs to get removed. I'm piping 'git archive --tar' to a 'tar -e' process and the terminal explodes.
